### PR TITLE
Stop crowbot from talking to itself

### DIFF
--- a/server.js
+++ b/server.js
@@ -110,7 +110,7 @@ bot.addListener("join",function(channel,who){
 });
 
 function handler(from, to, message) {
-  if (from == 'ghservo') {
+  if (from == 'ghservo' || from.match(/crowbot/)) {
     return;
   }
 


### PR DESCRIPTION
If there are two of them in the room, they get really excited and drown out everyone else.